### PR TITLE
Fix invert-color text on staff

### DIFF
--- a/source/sass/_invert-color.sass
+++ b/source/sass/_invert-color.sass
@@ -29,6 +29,10 @@
 
   .local
     background-image: none
+    
+  .staff-list
+    a
+      color: $black
 
   .contact
     h4


### PR DESCRIPTION
Was getting white text on white background in staff names.